### PR TITLE
Fix/admin user initialization

### DIFF
--- a/backend/src/main/java/com/example/backend/config/AdminInitializerConfig.java
+++ b/backend/src/main/java/com/example/backend/config/AdminInitializerConfig.java
@@ -1,0 +1,70 @@
+package com.example.backend.config;
+
+import com.example.backend.models.User;
+import com.example.backend.repository.UserRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+import java.time.LocalDateTime;
+
+/**
+ * Konfiguracja inicjalizacji użytkownika administracyjnego.
+ * <p>
+ * Klasa odpowiedzialna za sprawdzanie i tworzenie użytkownika administracyjnego
+ * przy każdym uruchomieniu aplikacji, jeśli taki użytkownik nie istnieje w bazie danych.
+ * </p>
+ *
+ * @author Jakub
+ * @version 1.0.0
+ * @since 1.0.0
+ */
+@Configuration
+public class AdminInitializerConfig {
+
+    private static final Logger logger = LoggerFactory.getLogger(AdminInitializerConfig.class);
+
+    private final UserRepository userRepository;
+    private final BCryptPasswordEncoder passwordEncoder;
+
+    @Autowired
+    public AdminInitializerConfig(UserRepository userRepository, BCryptPasswordEncoder passwordEncoder) {
+        this.userRepository = userRepository;
+        this.passwordEncoder = passwordEncoder;
+    }
+
+    /**
+     * Bean CommandLineRunner, który sprawdza i tworzy użytkownika administracyjnego
+     * przy każdym uruchomieniu aplikacji.
+     *
+     * @return CommandLineRunner, który wykonuje operację sprawdzania i tworzenia admina
+     */
+    @Bean
+    public CommandLineRunner initializeAdminUser() {
+        return args -> {
+            if (!userRepository.existsByUsername("admin")) {
+                logger.info("Użytkownik administracyjny nie istnieje. Tworzenie nowego użytkownika admin...");
+
+                User adminUser = new User();
+                adminUser.setUsername("admin");
+                adminUser.setPassword(passwordEncoder.encode("admin123"));
+                adminUser.setEmail("admin@example.com");
+                adminUser.setFirstName("System");
+                adminUser.setLastName("Administrator");
+                adminUser.setRole("administrator");
+                adminUser.setIsActive(true);
+                adminUser.setCreatedAt(LocalDateTime.now());
+
+                userRepository.save(adminUser);
+
+                logger.info("Użytkownik administracyjny został pomyślnie utworzony");
+            } else {
+                logger.debug("Użytkownik administracyjny już istnieje w bazie danych");
+            }
+        };
+    }
+}

--- a/backend/src/main/resources/db/changelog/04-insert-basic-data.xml
+++ b/backend/src/main/resources/db/changelog/04-insert-basic-data.xml
@@ -5,20 +5,6 @@
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.5.xsd">
 
-    <!-- Podstawowy użytkownik admin -->
-    <changeSet id="12-insert-admin-user" author="your-name">
-        <insert tableName="users">
-            <column name="username" value="admin"/>
-            <!-- Hasło: admin123 (zahaszowane) -->
-            <column name="password" value="$2a$10$rJLq2nt5H1ot.ZQfzwQ.e.TY7ABh2stNesvTRWh2UDpaVzM9JL.yC"/>
-            <column name="email" value="admin@example.com"/>
-            <column name="first_name" value="System"/>
-            <column name="last_name" value="Administrator"/>
-            <column name="role" value="administrator"/>
-            <column name="is_active" valueBoolean="true"/>
-        </insert>
-    </changeSet>
-
     <!-- Podstawowe priorytety -->
     <changeSet id="13-insert-priorities" author="your-name">
         <insert tableName="priorities">


### PR DESCRIPTION
## **Description**
This PR resolves an issue with the admin user initialization in the system. Previously, the admin user was created through Liquibase with a manually entered password hash, which was not reliable. The new approach uses a programmatic solution that ensures an admin user is always available in the system.
Problem

## **Solution**
- Created a dedicated AdminInitializerConfig class that runs on application startup
- The class checks if an admin user exists and creates one if it doesn't
- Password is properly hashed at runtime using the Spring Security BCryptPasswordEncoder
- Removed the admin user creation from Liquibase migrations

## **Changes Made**
- Added new AdminInitializerConfig class with CommandLineRunner bean to initialize admin user
- Removed admin user creation from 04-insert-basic-data.xml Liquibase changeset
- Password is now correctly hashed at runtime using Spring Security's BCryptPasswordEncoder
<hr>

![8kv8yr](https://github.com/user-attachments/assets/807b85a1-8619-4b17-bbfb-a4218cf5e4db)
