### PR TITLE
Refactor UI, restrict access by role, and extend task/report modules

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,7 +11,8 @@
         "axios": "^1.8.4",
         "dotenv": "^16.4.5",
         "vue": "^3.5.13",
-        "vue-router": "^4.5.0"
+        "vue-router": "^4.5.0",
+        "vue3-datepicker": "^0.4.0"
       },
       "devDependencies": {
         "@vitejs/plugin-vue": "^5.2.1",
@@ -67,6 +68,14 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.1.tgz",
+      "integrity": "sha512-1x3D2xEk2fRo3PAhwQwu5UubzgiVWSXTBfWpVd2Mx2AzRqJuDJCsgaDVZ7HB5iGzDW1Hl1sWN2mFyKjmR9uAog==",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/types": {
@@ -3113,6 +3122,21 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
       "license": "MIT"
+    },
+    "node_modules/date-fns": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
+      "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
+      "dependencies": {
+        "@babel/runtime": "^7.21.0"
+      },
+      "engines": {
+        "node": ">=0.11"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/date-fns"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.0",
@@ -7825,6 +7849,20 @@
       },
       "peerDependencies": {
         "vue": "^3.2.0"
+      }
+    },
+    "node_modules/vue3-datepicker": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/vue3-datepicker/-/vue3-datepicker-0.4.0.tgz",
+      "integrity": "sha512-o0/y4yuZZc0DXYhiAlX8Znrkm/zvkeYuyV9PUt0UAvwxkno2jqMS388jVUa9Ns+a2s2pOAAybyXo5uQ9YAIwVw==",
+      "dependencies": {
+        "date-fns": "^2.22.1"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      },
+      "peerDependencies": {
+        "vue": "^3.0.0"
       }
     },
     "node_modules/wcwidth": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,7 +14,8 @@
     "axios": "^1.8.4",
     "dotenv": "^16.4.5",
     "vue": "^3.5.13",
-    "vue-router": "^4.5.0"
+    "vue-router": "^4.5.0",
+    "vue3-datepicker": "^0.4.0"
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^5.2.1",

--- a/frontend/router/router.js
+++ b/frontend/router/router.js
@@ -20,6 +20,9 @@ import AddTask from '@/components/AddTask.vue';
 import EditTask from '@/components/TaskEdit.vue';
 import TaskDetails from '@/components/TaskDetails.vue';
 import TeamMembersManage from '@/components/TeamMembersManage.vue';
+import RaportMenu from '@/components/RaportMenu.vue';
+import TaskMenu from '@/components/TaskMenu.vue';
+import AdminPanelMenu from '@/components/AdminPanelMenu.vue';
 
 export const authState = reactive({
   isAuthenticated: false,
@@ -34,13 +37,16 @@ const routes = [
   { path: '/teamtasks/:id', name: "teamTasks", component: TeamsTasks, props: true, meta: { requiresAuth: true } },
   { path: '/allemployees', name: "allEmployees", component: AllEmployees, meta: { requiresAuth: true, minRole: 'kierownik' } },
   { path: '/addemployee', name: "addEmployee", component: AddEmployee, meta: { requiresAuth: true, minRole: 'kierownik' } },
+  { path: '/raport', name: "raportMenu", component: RaportMenu, meta: { requiresAuth: true, minRole: 'kierownik' } },
   { path: '/raportgenerate', name: "raportGenerate", component: RaportGenerate, meta: { requiresAuth: true, minRole: 'kierownik' } },
   { path: '/raporthistory', name: "raportHistory", component: RaportHistory, meta: { requiresAuth: true, minRole: 'kierownik' } },
-  { path: '/systemconf', name: "systemConf", component: SystemConf, meta: { requiresAuth: true, requiredRole: 'administrator' } },
-  { path: '/taskshistory', name: "tasksHistory", component: TasksHistory, meta: { requiresAuth: true } },
+  { path: '/tasks', name: "TaskMenu", component: TaskMenu, meta: { requiresAuth: true } },
   { path: '/addtask', name: "addTask", component: AddTask, meta: { requiresAuth: true, minRole: 'kierownik' } },
+  { path: '/taskshistory', name: "tasksHistory", component: TasksHistory, meta: { requiresAuth: true } },
+  { path: '/adminpanel', name: "adminPanelMenu", component: AdminPanelMenu, meta: { requiresAuth: true, requiredRole: 'administrator' } },
   { path: '/settings', name: "userSettings", component: UserSettings, meta: { requiresAuth: true } },
   { path: '/allusers', name: "allUsers", component: AllUsers, meta: { requiresAuth: true, minRole: 'kierownik' } },
+  { path: '/systemconf', name: "systemConf", component: SystemConf, meta: { requiresAuth: true, requiredRole: 'administrator' } },
   { path: '/edittask/:id', name: "editTask", component: EditTask, meta: { requiresAuth: true, minRole: 'kierownik' }, props: true },
   { path: '/taskdetails/:id', name: "taskDetails", component: TaskDetails, meta: { requiresAuth: true } },
   {
@@ -57,7 +63,7 @@ const routes = [
     meta: { requiresAuth: true, minRole: 'kierownik' },
     props: route => ({ userId: parseInt(route.params.id) || null })
   },
-    {
+  {
     path: '/raportview/:id',
     name: "raportView",
     component: RaportView,

--- a/frontend/src/assets/datepicker.css
+++ b/frontend/src/assets/datepicker.css
@@ -1,0 +1,103 @@
+.datepicker-container {
+  position: relative;
+}
+datepicker-input-custom {
+  background-color: white !important;
+  color: black !important;
+  border: 1px solid #d1d5db !important;
+  border-radius: 0.5rem !important;
+  padding: 0.5rem 1rem !important; /* px-4 py-2 w Tailwind */
+  height: 2.75rem !important; /* Standardowa wysokość inputów Tailwind */
+  line-height: 1.25rem !important;
+  box-shadow: none !important;
+}
+
+.datepicker-input-custom:focus {
+  outline: none !important;
+  border-color: #3F51B5 !important;
+  box-shadow: 0 0 0 2px rgba(63, 81, 181, 0.2) !important;
+  background-color: white !important;
+}
+
+.datepicker-input-custom:hover {
+  border-color: #9ca3af !important;
+}
+
+/* Dodatkowe style dla kalendarza */
+.datepicker-calendar {
+  background-color: white !important;
+  border: 1px solid #d1d5db !important;
+  border-radius: 0.5rem !important;
+  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1) !important;
+}
+
+/* Wymuszenie białego tła i odpowiedniej wysokości dla wszystkich inputów datepicker */
+.v3dp__input_wrapper input {
+  background-color: white !important;
+  color: black !important;
+  padding: 0.5rem 1rem !important;
+  height: 2.75rem !important;
+  line-height: 1.25rem !important;
+  border: 1px solid #d1d5db !important;
+  border-radius: 0.5rem !important;
+  box-shadow: none !important;
+}
+
+.v3dp__input_wrapper input:focus {
+  background-color: white !important;
+  color: black !important;
+  border-color: #3F51B5 !important;
+  box-shadow: 0 0 0 2px rgba(63, 81, 181, 0.2) !important;
+}
+
+.v3dp__input_wrapper input:hover {
+  border-color: #9ca3af !important;
+}
+
+/* Alternatywne selektory dla różnych wersji Vue3 Datepicker */
+input[type="text"] {
+  background-color: white !important;
+  color: black !important;
+  min-height: 2.75rem !important;
+  border: 1px solid #d1d5db !important;
+  border-radius: 0.5rem !important;
+}
+
+.datepicker input {
+  background-color: white !important;
+  color: black !important;
+  padding: 0.5rem 1rem !important;
+  height: 2.75rem !important;
+  box-sizing: border-box !important;
+  border: 1px solid #d1d5db !important;
+  border-radius: 0.5rem !important;
+  box-shadow: none !important;
+}
+
+/* Dodatkowe wymuszenie wysokości dla wszystkich możliwych selektorów */
+.datepicker-container input,
+.datepicker-wrapper input,
+[data-datepicker] input {
+  background-color: white !important;
+  color: black !important;
+  padding: 0.5rem 1rem !important;
+  height: 2.75rem !important;
+  line-height: 1.25rem !important;
+  box-sizing: border-box !important;
+  border: 1px solid #d1d5db !important;
+  border-radius: 0.5rem !important;
+  box-shadow: none !important;
+}
+
+.datepicker-container input:focus,
+.datepicker-wrapper input:focus,
+[data-datepicker] input:focus {
+  border-color: #3F51B5 !important;
+  box-shadow: 0 0 0 2px rgba(63, 81, 181, 0.2) !important;
+}
+
+.datepicker-container input:hover,
+.datepicker-wrapper input:hover,
+[data-datepicker] input:hover {
+  border-color: #9ca3af !important;
+}

--- a/frontend/src/components/AddTask.vue
+++ b/frontend/src/components/AddTask.vue
@@ -1,136 +1,133 @@
 <template>
-  <div class="min-h-screen bg-background flex items-center justify-center px-4 py-10">
-    <div class="w-full max-w-2xl bg-surface border border-gray-200 rounded-2xl shadow-xl p-8 space-y-6">
-      <h1 class="text-3xl font-bold text-primary">Dodaj zadanie</h1>
+  <div class="min-h-screen bg-background flex flex-col items-start justify-start px-10 py-10 space-y-8">
+    <!-- Nagłówek -->
+    <h1 class="text-3xl font-bold text-primary">Dodaj zadanie</h1>
 
-      <div v-if="dataLoading" class="text-center py-6">
-        <p class="text-primary text-xl">Ładowanie danych...</p>
+    <!-- Loader -->
+    <div v-if="dataLoading" class="text-primary text-xl">Ładowanie danych...</div>
+
+    <!-- Formularz -->
+    <form v-else @submit.prevent="addTask" class="space-y-5 w-full max-w-3xl">
+      
+      <!-- Pole: Tytuł -->
+      <div class="flex items-center space-x-4">
+        <label for="title" class="w-48 text-black text-lg font-medium">Tytuł zadania</label>
+        <input
+          v-model="task.title"
+          id="title"
+          type="text"
+          required
+          class="flex-1 p-2.5 border border-gray-300 rounded-md bg-white text-sm text-black placeholder-gray-400 focus:ring-2 focus:ring-primary focus:outline-none"
+          placeholder="np. Remont mieszkania ul. Załęska 76"
+        />
       </div>
 
-      <form v-else @submit.prevent="addTask" class="space-y-5">
-        <div>
-          <label for="title" class="block text-lg text-black font-medium mb-2">Tytuł zadania</label>
-          <input
-              v-model="task.title"
-              id="title"
-              type="text"
-              required
-              class="w-full p-2.5 border border-gray-300 rounded-md bg-white text-sm text-black placeholder-gray-400 focus:ring-2 focus:ring-primary focus:outline-none"
-              placeholder="np. Remont mieszkania ul. Załęska 76"
-          />
-        </div>
+      <!-- Pole: Opis -->
+      <div class="flex items-start space-x-4">
+        <label for="description" class="w-48 text-black text-lg font-medium pt-2">Opis zadania</label>
+        <textarea
+          v-model="task.description"
+          id="description"
+          rows="4"
+          class="flex-1 p-2.5 border border-gray-300 rounded-md bg-white text-sm text-black placeholder-gray-400 focus:ring-2 focus:ring-primary focus:outline-none"
+          placeholder="np. Klient ma problemy z wilgocią..."
+        ></textarea>
+      </div>
 
-        <div>
-          <label for="description" class="block text-lg text-black font-medium mb-2">Opis zadania</label>
-          <textarea
-              v-model="task.description"
-              id="description"
-              rows="4"
-              class="w-full p-2.5 border border-gray-300 rounded-md bg-white text-sm text-black placeholder-gray-400 focus:ring-2 focus:ring-primary focus:outline-none"
-              placeholder="np. Klient ma problemy z wilgocią..."
-          ></textarea>
-        </div>
+      <!-- Pole: Zespół -->
+      <div class="flex items-center space-x-4">
+        <label for="teamId" class="w-48 text-black text-lg font-medium">Zespół</label>
+        <select
+          v-model.number="task.teamId"
+          id="teamId"
+          required
+          class="flex-1 p-2.5 border border-gray-300 rounded-md bg-white text-sm text-black focus:ring-2 focus:ring-primary focus:outline-none"
+        >
+          <option disabled value="">Wybierz zespół</option>
+          <option v-for="team in teams" :key="team.id" :value="team.id">{{ team.name }}</option>
+        </select>
+      </div>
 
-        <div>
-          <label for="teamId" class="block text-lg text-black font-medium mb-2">Zespół</label>
+      <!-- Priorytet i Status -->
+      <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div class="flex items-center space-x-4">
+          <label for="priorityId" class="w-48 text-black text-lg font-medium">Priorytet</label>
           <select
-              v-model.number="task.teamId"
-              id="teamId"
-              required
-              class="w-full p-2.5 border border-gray-300 rounded-md bg-white text-sm text-black focus:ring-2 focus:ring-primary focus:outline-none"
+            v-model.number="task.priorityId"
+            id="priorityId"
+            required
+            class="flex-1 p-2.5 border border-gray-300 rounded-md bg-white text-sm text-black focus:ring-2 focus:ring-primary focus:outline-none"
           >
-            <option disabled value="" class="text-gray-400">Wybierz zespół</option>
-            <option v-for="team in teams" :key="team.id" :value="team.id">{{ team.name }}</option>
+            <option disabled value="">Wybierz priorytet</option>
+            <option v-for="priority in priorities" :key="priority.id" :value="priority.id">{{ priority.name }}</option>
           </select>
         </div>
 
-        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-          <div>
-            <label for="priorityId" class="block text-lg text-black font-medium mb-2">Priorytet</label>
-            <select
-                v-model.number="task.priorityId"
-                id="priorityId"
-                required
-                class="w-full p-2.5 border border-gray-300 rounded-md bg-white text-sm text-black focus:ring-2 focus:ring-primary focus:outline-none"
-            >
-              <option disabled value="" class="text-gray-400">Wybierz priorytet</option>
-              <option v-for="priority in priorities" :key="priority.id" :value="priority.id">{{ priority.name }}</option>
-            </select>
-          </div>
+        <div class="flex items-center space-x-4">
+          <label for="statusId" class="w-48 text-black text-lg font-medium">Status</label>
+          <select
+            v-model.number="task.statusId"
+            id="statusId"
+            required
+            class="flex-1 p-2.5 border border-gray-300 rounded-md bg-white text-sm text-black focus:ring-2 focus:ring-primary focus:outline-none"
+          >
+            <option disabled value="">Wybierz status</option>
+            <option v-for="status in statuses" :key="status.id" :value="status.id">{{ status.name }}</option>
+          </select>
+        </div>
+      </div>
 
-          <div>
-            <label for="statusId" class="block text-lg text-black font-medium mb-2">Status</label>
-            <select
-                v-model.number="task.statusId"
-                id="statusId"
-                required
-                class="w-full p-2.5 border border-gray-300 rounded-md bg-white text-sm text-black focus:ring-2 focus:ring-primary focus:outline-none"
-            >
-              <option disabled value="" class="text-gray-400">Wybierz status</option>
-              <option v-for="status in statuses" :key="status.id" :value="status.id">{{ status.name }}</option>
-            </select>
+      <!-- Daty -->
+      <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div class="flex items-center space-x-4">
+          <label for="startDate" class="w-48 text-black text-lg font-medium">Data rozpoczęcia</label>
+          <div class="flex-1 datepicker-wrapper">
+            <Datepicker
+              v-model="task.startDate"
+              :input-class="'w-full p-2.5 border border-gray-300 rounded-md bg-white text-sm text-black focus:ring-2 focus:ring-primary focus:outline-none datepicker-input'"
+              :format="'yyyy-MM-dd'"
+              :id="'startDate'"
+              required
+            />
           </div>
         </div>
 
-        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-          <div>
-            <label for="startDate" class="block text-lg text-black font-medium mb-2">Data rozpoczęcia</label>
-            <div class="relative">
-              <input
-                  v-model="task.startDate"
-                  id="startDate"
-                  type="date"
-                  required
-                  class="w-full p-2.5 pl-10 cursor-pointer border border-gray-300 rounded-md bg-white text-sm text-black focus:ring-2 focus:ring-primary focus:outline-none"
-              />
-              <span class="absolute inset-y-0 left-3 flex items-center text-gray-500">
-                <i class="fas fa-calendar-alt"></i>
-              </span>
-            </div>
-          </div>
-
-          <div>
-            <label for="deadline" class="block text-lg text-black font-medium mb-2">Deadline</label>
-            <div class="relative">
-              <input
-                  v-model="task.deadline"
-                  id="deadline"
-                  type="date"
-                  required
-                  class="w-full p-2.5 pl-10 cursor-pointer border border-gray-300 rounded-md bg-white text-sm text-black focus:ring-2 focus:ring-primary focus:outline-none"
-              />
-              <span class="absolute inset-y-0 left-3 flex items-center text-gray-500">
-                <i class="fas fa-calendar-alt"></i>
-              </span>
-            </div>
+        <div class="flex items-center space-x-4">
+          <label for="deadline" class="w-48 text-black text-lg font-medium">Deadline</label>
+          <div class="flex-1 datepicker-wrapper">
+            <Datepicker
+              v-model="task.deadline"
+              :input-class="'w-full p-2.5 border border-gray-300 rounded-md bg-white text-sm text-black focus:ring-2 focus:ring-primary focus:outline-none datepicker-input'"
+              :format="'yyyy-MM-dd'"
+              :id="'deadline'"
+              required
+            />
           </div>
         </div>
+      </div>
 
-        <div class="flex justify-between pt-4">
-          <div class="flex gap-4">
-            <button
-                type="button"
-                @click="goBack"
-                class="px-5 py-2 rounded-md bg-gray-500 text-white text-sm hover:bg-gray-600 transition"
-            >
-              Anuluj
-            </button>
-            <button
-                type="submit"
-                class="px-6 py-2 rounded-md bg-primary hover:bg-secondary text-white text-sm font-semibold transition"
-                :disabled="loading"
-            >
-              <span v-if="loading">Dodawanie...</span>
-              <span v-else>Dodaj zadanie</span>
-            </button>
-          </div>
-        </div>
-      </form>
-    </div>
-  </div>
+      <!-- Przyciski -->
+      <div class="flex justify-end gap-4 pt-4">
+        <button
+          type="button"
+          @click="goBack"
+          class="px-5 py-2 rounded-md bg-gray-500 text-white text-sm hover:bg-gray-600 transition"
+        >
+          Anuluj
+        </button>
+        <button
+          type="submit"
+          class="px-6 py-2 rounded-md bg-primary hover:bg-secondary text-white text-sm font-semibold transition"
+          :disabled="loading"
+        >
+          <span v-if="loading">Dodawanie...</span>
+          <span v-else>Dodaj zadanie</span>
+        </button>
+      </div>
+    </form>
 
-  <!-- Status Modal -->
-  <StatusModal
+    <!-- Status Modal -->
+    <StatusModal
       :show="showModal"
       :type="modalConfig.type"
       :title="modalConfig.title"
@@ -139,7 +136,8 @@
       :auto-close="modalConfig.autoClose"
       :auto-close-delay="modalConfig.autoCloseDelay"
       @close="hideModal"
-  />
+    />
+  </div>
 </template>
 
 <script setup>
@@ -152,6 +150,7 @@ import taskStatusService from '../services/taskStatusService';
 import { authState } from '../../router/router.js';
 import StatusModal from './StatusModal.vue';
 import { useStatusModal } from '../composables/useStatusModal';
+import Datepicker from 'vue3-datepicker';
 
 const router = useRouter();
 
@@ -162,8 +161,8 @@ const task = ref({
   teamId: '',
   priorityId: '',
   statusId: '',
-  startDate: '',
-  deadline: ''
+  startDate: null,
+  deadline: null
   // Pola id, createdById i createdAt będą dodane przez backend
 });
 
@@ -255,12 +254,12 @@ const fetchReferenceData = async () => {
 onMounted(async () => {
   // Ustawienie domyślnej daty rozpoczęcia na dzisiaj
   const today = new Date();
-  task.value.startDate = today.toISOString().split('T')[0];
+  task.value.startDate = today;
 
   // Ustawienie domyślnego deadlinu na tydzień od dziś
   const nextWeek = new Date();
   nextWeek.setDate(nextWeek.getDate() + 7);
-  task.value.deadline = nextWeek.toISOString().split('T')[0];
+  task.value.deadline = nextWeek;
 
   // Pobierz dane referencyjne
   await fetchReferenceData();
@@ -316,14 +315,16 @@ const addTask = async () => {
     });
 
     // Przekształcenie danych do formatu API zgodnego z oczekiwanym JSON
+    const formatDate = (date) => date ? date.toISOString().split('T')[0] : '';
+
     const taskData = {
       title: task.value.title,
       description: task.value.description || '',
       teamId: task.value.teamId,
       priorityId: task.value.priorityId,
       statusId: task.value.statusId,
-      startDate: task.value.startDate,
-      deadline: task.value.deadline,
+      startDate: formatDate(task.value.startDate),
+      deadline: formatDate(task.value.deadline),
       createdById: userId
     };
 
@@ -354,7 +355,7 @@ const addTask = async () => {
     });
 
   } catch (err) {
-    console.error('Błąd podczas dodawania zadania:', err);
+    console.error('Błąd podczas dodawania zadania:',  err);
     showStatus({
       type: 'error',
       title: 'Błąd',

--- a/frontend/src/components/AddTask.vue
+++ b/frontend/src/components/AddTask.vue
@@ -315,7 +315,13 @@ const addTask = async () => {
     });
 
     // Przekształcenie danych do formatu API zgodnego z oczekiwanym JSON
-    const formatDate = (date) => date ? date.toISOString().split('T')[0] : '';
+    const formatDate = (date) => {
+      if (!date) return '';
+      const year = date.getFullYear();
+      const month = String(date.getMonth() + 1).padStart(2, '0');
+      const day = String(date.getDate()).padStart(2, '0');
+      return `${year}-${month}-${day}`;
+    };
 
     const taskData = {
       title: task.value.title,

--- a/frontend/src/components/AddTeam.vue
+++ b/frontend/src/components/AddTeam.vue
@@ -126,7 +126,7 @@ export default {
     const fetchManagers = async () => {
       try {
         const users = await userService.getActiveUsers();
-        managers.value = users.filter(user => user.role === 'kierownik' || user.role === 'administrator');
+        managers.value = users.filter(user => user.role === 'kierownik');
         console.log('Pobrano kierowników:', managers.value);
       } catch (err) {
         console.error('Błąd podczas pobierania kierowników:', err);

--- a/frontend/src/components/AddTeam.vue
+++ b/frontend/src/components/AddTeam.vue
@@ -150,7 +150,8 @@ export default {
     const fetchEmployees = async () => {
       try {
         const users = await userService.getActiveUsers();
-        employees.value = users;
+        // Filtrowanie tylko pracowników (bez administratora i kierownika)
+        employees.value = users.filter(user => user.role === 'pracownik');
         console.log('Pobrano pracowników:', employees.value);
       } catch (err) {
         console.error('Błąd podczas pobierania pracowników:', err);

--- a/frontend/src/components/AdminPanelMenu.vue
+++ b/frontend/src/components/AdminPanelMenu.vue
@@ -1,0 +1,43 @@
+<template>
+  <div class="p-4">
+    <div class="flex justify-between items-center mb-4">
+      <h1 class="text-3xl text-left font-bold text-primary mb-6">
+          Panel administratora
+        </h1>
+        <div>
+          <button
+            :class="activeTab === 'users' ? 'bg-accent' : 'bg-secondary'"
+            class="text-white px-4 py-2 rounded mr-2 bg-primary hover:bg-secondary"
+            @click="activeTab = 'users'"
+          >
+            Ustawienia użytkowników
+          </button>
+          <button
+            :class="activeTab === 'system' ? 'bg-accent' : 'bg-secondary'"
+            class="text-white px-4 py-2 rounded bg-primary hover:bg-secondary"
+            @click="activeTab = 'system'"
+          >
+            Ustawienia systemu
+          </button>
+        </div>
+      </div>
+      <div>
+        <AllUsers v-if="activeTab === 'users'" />
+        <SystemConf v-else />
+      </div>
+    </div>
+</template>
+
+<script>
+import AllUsers from './AllUsers.vue';
+import SystemConf from './SystemConf.vue';
+
+export default {
+  components: { AllUsers, SystemConf },
+  data() {
+    return {
+      activeTab: 'users'
+    };
+  }
+};
+</script>

--- a/frontend/src/components/AllUsers.vue
+++ b/frontend/src/components/AllUsers.vue
@@ -62,12 +62,19 @@
             </button>
             <!-- Przyciski aktywacji/dezaktywacji - pokazane tylko wtedy, gdy użytkownik ma uprawnienia -->
             <button
-                v-if="canEditUser(employee) && employee.isActive"
+                v-if="canEditUser(employee) && employee.isActive && !isUserAdmin(employee)"
                 @click="deactivateEmployee(employee.id)"
                 class="text-xs bg-yellow-500 text-white px-2 py-1 rounded-md hover:bg-yellow-600 transition"
             >
               Dezaktywuj
             </button>
+            <!-- Informacja o braku możliwości dezaktywacji administratora -->
+            <span
+                v-if="canEditUser(employee) && employee.isActive && isUserAdmin(employee)"
+                class="text-xs text-gray-500 italic"
+            >
+              Nie można dezaktywować administratora
+            </span>
             <button
                 v-if="canEditUser(employee) && !employee.isActive"
                 @click="activateEmployee(employee.id)"
@@ -157,8 +164,7 @@ export default {
     // Czy użytkownik jest administratorem (na podstawie jego roli)
     const isUserAdmin = (user) => {
       return user.role === 'admin' ||
-          user.role === 'administrator' ||
-          user.role === 'ADMIN';
+          user.role === 'administrator';
     };
 
     // Czy użytkownik jest pracownikiem (na podstawie jego roli)
@@ -312,7 +318,8 @@ export default {
       activateEmployee,
       removeEmployee,
       confirmAction,
-      getRoleName
+      getRoleName,
+      isUserAdmin
     };
   }
 };

--- a/frontend/src/components/Navbar.vue
+++ b/frontend/src/components/Navbar.vue
@@ -8,25 +8,29 @@
       </button>
       <router-link
           to="/teams"
-          class="text-white block bg-secondary hover:bg-accent p-3 rounded mb-3 transition">
+          :class="navLinkClass('teams')"
+          @click.native="setActiveTab('teams')">
         Zespoły
       </router-link>
       <router-link
           v-if="canAccessManagerFeatures"
           to="/raport"
-          class="!text-white block bg-secondary hover:bg-accent p-3 rounded mb-3 transition">
+          :class="navLinkClass('raport')"
+          @click.native="setActiveTab('raport')">
         Raporty
       </router-link>
       <router-link
           v-if="canAccessManagerFeatures"
           to="/tasks"
-          class="!text-white block bg-secondary hover:bg-accent p-3 rounded mb-3 transition">
+          :class="navLinkClass('tasks')"
+          @click.native="setActiveTab('tasks')">
         Zadania
       </router-link>
       <router-link
           v-if="isAdmin"
           to="/adminpanel"
-          class="!text-white block bg-secondary hover:bg-accent p-3 rounded mb-3 transition">
+          :class="navLinkClass('adminpanel')"
+          @click.native="setActiveTab('adminpanel')">
         Panel administratora
       </router-link>
     </div>
@@ -49,6 +53,11 @@ import { authState } from '../../router/router.js';
 import authService from '../services/authService';
 
 export default {
+  data() {
+    return {
+      activeTab: null
+    };
+  },
   computed: {
     canAccessManagerFeatures() {
       return authService.hasRoleAtLeast('kierownik');
@@ -65,6 +74,15 @@ export default {
     }
   },
   methods: {
+    setActiveTab(tab) {
+      this.activeTab = tab;
+    },
+    navLinkClass(tab) {
+      return [
+        'block bg-secondary hover:bg-accent p-3 rounded mb-3 transition !text-white',
+        this.activeTab === tab ? 'ring-2 ring-accent font-bold' : ''
+      ];
+    },
     goBack() {
       if (authState.isAuthenticated) {
         this.$router.go(-1);

--- a/frontend/src/components/Navbar.vue
+++ b/frontend/src/components/Navbar.vue
@@ -34,11 +34,12 @@
           class="!text-white block bg-secondary hover:bg-accent p-3 rounded mb-3 transition">
         Zarządzanie użytkownikami
       </router-link>
-      <router-link
+      <!-- Usunięcie ustawień użytkownika - edycja tylko kierownik/admin -->
+      <!-- <router-link
           to="/settings"
           class="text-white block bg-secondary hover:bg-accent p-3 rounded mb-3 transition">
         Ustawienia użytkownika
-      </router-link>
+      </router-link> -->
       <router-link
           v-if="isAdmin"
           to="/systemconf"

--- a/frontend/src/components/Navbar.vue
+++ b/frontend/src/components/Navbar.vue
@@ -32,6 +32,9 @@
     </div>
 
     <div class="p-4">
+      <div v-if="userFullName" class="mb-2 font-semibold text-center">
+        Użytkownik: {{ userFullName }}
+      </div>
       <button
           @click="logout"
           class="w-full bg-warning hover:bg-warningHover text-white px-4 py-2 rounded transition mb-2">
@@ -52,6 +55,13 @@ export default {
     },
     isAdmin() {
       return authState.user?.role === 'administrator';
+    },
+    userFullName() {
+      const user = authState.user;
+      if (user && user.firstName && user.lastName) {
+        return `${user.firstName} ${user.lastName}`;
+      }
+      return '';
     }
   },
   methods: {

--- a/frontend/src/components/Navbar.vue
+++ b/frontend/src/components/Navbar.vue
@@ -29,7 +29,7 @@
         Historia zadań
       </router-link>
       <router-link
-          v-if="canAccessManagerFeatures"
+          v-if="isAdmin"
           to="/allusers"
           class="!text-white block bg-secondary hover:bg-accent p-3 rounded mb-3 transition">
         Zarządzanie użytkownikami

--- a/frontend/src/components/Navbar.vue
+++ b/frontend/src/components/Navbar.vue
@@ -13,38 +13,21 @@
       </router-link>
       <router-link
           v-if="canAccessManagerFeatures"
-          to="/raportgenerate"
+          to="/raport"
           class="!text-white block bg-secondary hover:bg-accent p-3 rounded mb-3 transition">
-        Generowanie Raportów
+        Raporty
       </router-link>
       <router-link
           v-if="canAccessManagerFeatures"
-          to="/raporthistory"
+          to="/tasks"
           class="!text-white block bg-secondary hover:bg-accent p-3 rounded mb-3 transition">
-        Historia Raportów
-      </router-link>
-      <router-link
-          to="/taskshistory"
-          class="!text-white block bg-secondary hover:bg-accent p-3 rounded mb-3 transition">
-        Historia zadań
+        Zadania
       </router-link>
       <router-link
           v-if="isAdmin"
-          to="/allusers"
+          to="/adminpanel"
           class="!text-white block bg-secondary hover:bg-accent p-3 rounded mb-3 transition">
-        Zarządzanie użytkownikami
-      </router-link>
-      <!-- Usunięcie ustawień użytkownika - edycja tylko kierownik/admin -->
-      <!-- <router-link
-          to="/settings"
-          class="text-white block bg-secondary hover:bg-accent p-3 rounded mb-3 transition">
-        Ustawienia użytkownika
-      </router-link> -->
-      <router-link
-          v-if="isAdmin"
-          to="/systemconf"
-          class="!text-white block bg-secondary hover:bg-accent p-3 rounded mb-3 transition">
-        Ustawienia systemu
+        Panel administratora
       </router-link>
     </div>
 

--- a/frontend/src/components/RaportHistory.vue
+++ b/frontend/src/components/RaportHistory.vue
@@ -46,7 +46,7 @@
             <p class="text-xs text-muted">Plik: {{ report.fileName || "Raport PDF" }}</p>
           </div>
           <div class="mt-4 flex space-x-3">
-            <button @click="openReportDetails(report)" class="border border-primary text-primary px-4 py-2 rounded-md hover:bg-primary hover:text-white transition">
+            <button @click="openReportDetails(report)" class="border border-primary text-primary px-4 py-2 rounded-md bg-primary text-white transition">
               Szczegóły
             </button>
           </div>

--- a/frontend/src/components/RaportMenu.vue
+++ b/frontend/src/components/RaportMenu.vue
@@ -1,0 +1,46 @@
+<template>
+  <div class="p-4">
+    <div class="flex justify-between items-center mb-4">
+      <h1 class="text-3xl text-left font-bold text-primary mb-6">
+        Raporty
+      </h1>
+      <div>
+        <button
+          :class="activeTab === 'generate' ? 'bg-accent' : 'bg-secondary'"
+          class="text-white px-4 py-2 rounded mr-2 bg-primary hover:bg-secondary"
+          @click="activeTab = 'generate'"
+        >
+          Generowanie raportów
+        </button>
+        <button
+          :class="activeTab === 'history' ? 'bg-accent' : 'bg-secondary'"
+          class="text-white px-4 py-2 rounded bg-primary hover:bg-secondary"
+          @click="activeTab = 'history'"
+        >
+          Historia raportów
+        </button>
+      </div>
+    </div>
+    <div>
+      <RaportGenerate v-if="activeTab === 'generate'" />
+      <RaportHistory v-else />
+    </div>
+  </div>
+</template>
+
+<script>
+import RaportGenerate from '../components/RaportGenerate.vue';
+import RaportHistory from '../components/RaportHistory.vue';
+
+export default {
+  components: {
+    RaportGenerate,
+    RaportHistory,
+  },
+  data() {
+    return {
+      activeTab: 'generate',
+    };
+  },
+};
+</script>

--- a/frontend/src/components/TaskDetails.vue
+++ b/frontend/src/components/TaskDetails.vue
@@ -493,9 +493,7 @@ export default {
         return date.toLocaleDateString('pl-PL', {
           year: 'numeric',
           month: 'long',
-          day: 'numeric',
-          hour: '2-digit',
-          minute: '2-digit'
+          day: 'numeric'
         });
       } catch (err) {
         return dateString;

--- a/frontend/src/components/TaskEdit.vue
+++ b/frontend/src/components/TaskEdit.vue
@@ -1,119 +1,142 @@
 <template>
-  <div class="min-h-screen bg-background flex items-center justify-center px-4 py-10">
-    <div v-if="loading" class="text-center">
-      <p class="text-xl text-primary">Ładowanie zadania...</p>
-    </div>
+  <div class="min-h-screen bg-background flex flex-col items-start justify-start px-10 py-10 space-y-8">
+    <!-- Nagłówek -->
+    <h1 class="text-3xl font-bold text-primary">Edytuj zadanie</h1>
 
-    <div v-else-if="error" class="bg-red-100 border-l-4 border-red-500 text-red-700 p-4">
+    <!-- Loader -->
+    <div v-if="loading" class="text-primary text-xl">Ładowanie zadania...</div>
+
+    <!-- Błąd -->
+    <div v-else-if="error" class="bg-red-100 border-l-4 border-red-500 text-red-700 p-4 w-full max-w-3xl">
       <p>{{ error }}</p>
       <button @click="fetchTaskDetails" class="mt-2 bg-primary text-white px-4 py-1 rounded-md">
         Spróbuj ponownie
       </button>
     </div>
 
-    <div v-else class="w-full max-w-2xl bg-surface border border-gray-200 rounded-2xl shadow-xl p-8 space-y-6">
-      <h2 class="text-3xl font-bold text-primary text-center">Edytuj Zadanie</h2>
+    <!-- Formularz -->
+    <form
+      v-else
+      @submit.prevent="updateTask"
+      class="space-y-5 w-full max-w-3xl"
+    >
+      <!-- Tytuł -->
+      <div class="flex items-center space-x-4">
+        <label for="title" class="w-48 text-black text-lg font-medium">Tytuł zadania</label>
+        <input
+          v-model="task.title"
+          id="title"
+          type="text"
+          required
+          class="flex-1 p-2.5 border border-gray-300 rounded-md bg-white text-sm text-black placeholder-gray-400 focus:ring-2 focus:ring-primary focus:outline-none"
+          placeholder="np. Remont mieszkania ul. Załęska 76"
+        />
+      </div>
 
-      <form @submit.prevent="updateTask" class="space-y-4">
-        <div>
-          <label class="block text-lg font-medium mb-2">Tytuł</label>
-          <input
-              v-model="task.title"
-              type="text"
-              placeholder="Wprowadź tytuł zadania"
-              class="p-2 border border-gray-300 rounded-md w-full bg-white text-text focus:outline-none focus:ring-2 focus:ring-primary"
-              required
-          />
-        </div>
+      <!-- Opis -->
+      <div class="flex items-start space-x-4">
+        <label for="description" class="w-48 text-black text-lg font-medium pt-2">Opis zadania</label>
+        <textarea
+          v-model="task.description"
+          id="description"
+          rows="4"
+          class="flex-1 p-2.5 border border-gray-300 rounded-md bg-white text-sm text-black placeholder-gray-400 focus:ring-2 focus:ring-primary focus:outline-none"
+          placeholder="np. Klient ma problemy z wilgocią..."
+        ></textarea>
+      </div>
 
-        <div>
-          <label class="block text-lg font-medium mb-2">Opis</label>
-          <textarea
-              v-model="task.description"
-              placeholder="Wprowadź opis zadania"
-              class="p-2 border border-gray-300 rounded-md w-full bg-white text-text focus:outline-none focus:ring-2 focus:ring-primary"
-              rows="4"
-          ></textarea>
-        </div>
+      <!-- Zespół -->
+      <div class="flex items-center space-x-4">
+        <label for="teamId" class="w-48 text-black text-lg font-medium">Zespół</label>
+        <select
+          v-model.number="task.teamId"
+          id="teamId"
+          required
+          class="flex-1 p-2.5 border border-gray-300 rounded-md bg-white text-sm text-black focus:ring-2 focus:ring-primary focus:outline-none"
+        >
+          <option disabled value="">Wybierz zespół</option>
+          <option v-for="team in teams" :key="team.id" :value="team.id">{{ team.name }}</option>
+        </select>
+      </div>
 
-        <div>
-          <label class="block text-lg font-medium mb-2">Zespół</label>
+      <!-- Priorytet i Status -->
+      <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div class="flex items-center space-x-4">
+          <label for="priorityId" class="w-48 text-black text-lg font-medium">Priorytet</label>
           <select
-              v-model="task.teamId"
-              required
-              class="p-2 border border-gray-300 rounded-md w-full bg-white text-text focus:outline-none focus:ring-2 focus:ring-primary"
-          >
-            <option disabled value="">Wybierz zespół</option>
-            <option v-for="team in teams" :key="team.id" :value="team.id">{{ team.name }}</option>
-          </select>
-        </div>
-
-        <div>
-          <label class="block text-lg font-medium mb-2">Priorytet</label>
-          <select
-              v-model="task.priorityId"
-              required
-              class="p-2 border border-gray-300 rounded-md w-full bg-white text-text focus:outline-none focus:ring-2 focus:ring-primary"
+            v-model.number="task.priorityId"
+            id="priorityId"
+            required
+            class="flex-1 p-2.5 border border-gray-300 rounded-md bg-white text-sm text-black focus:ring-2 focus:ring-primary focus:outline-none"
           >
             <option disabled value="">Wybierz priorytet</option>
             <option v-for="priority in priorities" :key="priority.id" :value="priority.id">{{ priority.name }}</option>
           </select>
         </div>
-
-        <div>
-          <label class="block text-lg font-medium mb-2">Status</label>
+        <div class="flex items-center space-x-4">
+          <label for="statusId" class="w-48 text-black text-lg font-medium">Status</label>
           <select
-              v-model="task.statusId"
-              required
-              class="p-2 border border-gray-300 rounded-md w-full bg-white text-text focus:outline-none focus:ring-2 focus:ring-primary"
+            v-model.number="task.statusId"
+            id="statusId"
+            required
+            class="flex-1 p-2.5 border border-gray-300 rounded-md bg-white text-sm text-black focus:ring-2 focus:ring-primary focus:outline-none"
           >
             <option disabled value="">Wybierz status</option>
             <option v-for="status in statuses" :key="status.id" :value="status.id">{{ status.name }}</option>
           </select>
         </div>
+      </div>
 
-        <div class="flex flex-col md:flex-row gap-4">
-          <div class="flex-1">
-            <label class="block text-lg font-medium mb-2">Data rozpoczęcia</label>
-            <input
-                type="date"
-                v-model="task.startDate"
-                class="p-2 border border-gray-300 rounded-md w-full bg-white text-text focus:outline-none focus:ring-2 focus:ring-primary"
-            />
-          </div>
-          <div class="flex-1">
-            <label class="block text-lg font-medium mb-2">Deadline</label>
-            <input
-                type="date"
-                v-model="task.deadline"
-                class="p-2 border border-gray-300 rounded-md w-full bg-white text-text focus:outline-none focus:ring-2 focus:ring-primary"
+      <!-- Daty -->
+      <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div class="flex items-center space-x-4">
+          <label for="startDate" class="w-48 text-black text-lg font-medium">Data rozpoczęcia</label>
+          <div class="flex-1 datepicker-wrapper">
+            <Datepicker
+              v-model="task.startDate"
+              :input-class="'w-full p-2.5 border border-gray-300 rounded-md bg-white text-sm text-black focus:ring-2 focus:ring-primary focus:outline-none datepicker-input'"
+              :format="'yyyy-MM-dd'"
+              :id="'startDate'"
+              required
             />
           </div>
         </div>
-
-        <div class="flex justify-between mt-6">
-          <button
-              type="button"
-              @click="goBack"
-              class="bg-gray-500 hover:bg-gray-600 text-white px-6 py-2 rounded-md transition"
-          >
-            Anuluj
-          </button>
-          <button
-              type="submit"
-              class="bg-primary hover:bg-secondary text-white px-6 py-2 rounded-md transition w-1/2"
-              :disabled="isSaving"
-          >
-            <span v-if="isSaving">Zapisywanie...</span>
-            <span v-else>Zapisz zmiany</span>
-          </button>
+        <div class="flex items-center space-x-4">
+          <label for="deadline" class="w-48 text-black text-lg font-medium">Deadline</label>
+          <div class="flex-1 datepicker-wrapper">
+            <Datepicker
+              v-model="task.deadline"
+              :input-class="'w-full p-2.5 border border-gray-300 rounded-md bg-white text-sm text-black focus:ring-2 focus:ring-primary focus:outline-none datepicker-input'"
+              :format="'yyyy-MM-dd'"
+              :id="'deadline'"
+              required
+            />
+          </div>
         </div>
-      </form>
-    </div>
-  </div>
+      </div>
 
-  <!-- Status Modal -->
-  <StatusModal
+      <!-- Przyciski -->
+      <div class="flex justify-end gap-4 pt-4">
+        <button
+          type="button"
+          @click="goBack"
+          class="px-5 py-2 rounded-md bg-gray-500 text-white text-sm hover:bg-gray-600 transition"
+        >
+          Anuluj
+        </button>
+        <button
+          type="submit"
+          class="px-6 py-2 rounded-md bg-primary hover:bg-secondary text-white text-sm font-semibold transition"
+          :disabled="isSaving"
+        >
+          <span v-if="isSaving">Zapisywanie...</span>
+          <span v-else>Zapisz zmiany</span>
+        </button>
+      </div>
+    </form>
+
+    <!-- Status Modal -->
+    <StatusModal
       :show="showModal"
       :type="modalConfig.type"
       :title="modalConfig.title"
@@ -122,7 +145,8 @@
       :auto-close="modalConfig.autoClose"
       :auto-close-delay="modalConfig.autoCloseDelay"
       @close="hideModal"
-  />
+    />
+  </div>
 </template>
 
 <script>
@@ -135,11 +159,13 @@ import taskStatusService from '../services/taskStatusService';
 import { authState } from '../../router/router.js';
 import StatusModal from './StatusModal.vue';
 import { useStatusModal } from '../composables/useStatusModal';
+import Datepicker from 'vue3-datepicker';
 
 export default {
   name: 'TaskEdit',
   components: {
-    StatusModal
+    StatusModal,
+    Datepicker
   },
   props: {
     id: {
@@ -167,8 +193,8 @@ export default {
       teamId: null,
       priorityId: null,
       statusId: null,
-      startDate: '',
-      deadline: '',
+      startDate: null,
+      deadline: null,
       createdById: null
     });
 
@@ -208,8 +234,8 @@ export default {
           teamId: taskData.teamId || (taskData.team?.id) || null,
           priorityId: taskData.priorityId || (taskData.priority?.id) || null,
           statusId: taskData.statusId || (taskData.status?.id) || null,
-          startDate: taskData.startDate ? taskData.startDate.split('T')[0] : '',
-          deadline: taskData.deadline ? taskData.deadline.split('T')[0] : '',
+          startDate: taskData.startDate ? new Date(taskData.startDate) : null,
+          deadline: taskData.deadline ? new Date(taskData.deadline) : null,
           createdById: taskData.createdById || (taskData.createdBy?.id) || null
         };
 
@@ -315,6 +341,15 @@ export default {
           }
         }
 
+        // Formatowanie dat do yyyy-MM-dd (lokalnie, nie UTC)
+        const formatDate = (date) => {
+          if (!date) return '';
+          const year = date.getFullYear();
+          const month = String(date.getMonth() + 1).padStart(2, '0');
+          const day = String(date.getDate()).padStart(2, '0');
+          return `${year}-${month}-${day}`;
+        };
+
         // Przygotuj dane zadania do wysłania (upewnij się o poprawnych typach)
         const taskData = {
           title: task.value.title,
@@ -322,8 +357,8 @@ export default {
           teamId: parseInt(task.value.teamId),
           priorityId: parseInt(task.value.priorityId),
           statusId: parseInt(task.value.statusId),
-          startDate: task.value.startDate,
-          deadline: task.value.deadline
+          startDate: formatDate(task.value.startDate),
+          deadline: formatDate(task.value.deadline)
         };
 
         console.log('Wysyłanie aktualizacji zadania:', taskData);

--- a/frontend/src/components/TaskMenu.vue
+++ b/frontend/src/components/TaskMenu.vue
@@ -1,0 +1,43 @@
+<template>
+  <div class="p-4">
+    <div class="flex justify-between items-center mb-4">
+      <h1 class="text-3xl text-left font-bold text-primary mb-6">
+          Zadania
+        </h1>
+        <div>
+          <button
+            :class="activeTab === 'history' ? 'bg-accent' : 'bg-secondary'"
+            class="text-white px-4 py-2 rounded mr-2 bg-primary hover:bg-secondary"
+            @click="activeTab = 'history'"
+          >
+            Historia zadań
+          </button>
+          <button
+            :class="activeTab === 'add' ? 'bg-accent' : 'bg-secondary'"
+            class="text-white px-4 py-2 rounded bg-primary hover:bg-secondary"
+            @click="activeTab = 'add'"
+          >
+            Dodaj zadanie
+          </button>
+        </div>
+      </div>
+      <div>
+        <TasksHistory v-if="activeTab === 'history'" />
+        <AddTask v-else />
+      </div>
+    </div>
+</template>
+
+<script>
+import TasksHistory from './TasksHistory.vue';
+import AddTask from './AddTask.vue';
+
+export default {
+  components: { TasksHistory, AddTask },
+  data() {
+    return {
+      activeTab: 'history'
+    };
+  }
+};
+</script>

--- a/frontend/src/components/TeamDetails.vue
+++ b/frontend/src/components/TeamDetails.vue
@@ -65,7 +65,7 @@
 
         <!-- Nadchodzące Zadania -->
         <div class="bg-surface rounded-xl p-6 shadow border border-gray-200">
-          <h2 class="text-xl font-bold text-primary mb-4">Nadchodzące Zadania</h2>
+          <h2 class="text-xl font-bold text-primary mb-4">Zadania</h2>
           <div v-if="upcomingTasks.length === 0" class="text-muted text-center">
             Brak nadchodzących zadań
           </div>

--- a/frontend/src/components/TeamDetails.vue
+++ b/frontend/src/components/TeamDetails.vue
@@ -22,6 +22,7 @@
           </div>
         </div>
         <button
+          v-if="canManageMembers"
           @click="navigateToManageMembers"
           class="bg-primary text-white px-4 py-2 rounded-md shadow-md hover:bg-secondary transition"
         >
@@ -166,9 +167,10 @@
 
 
 <script>
-import { ref, onMounted, watch } from 'vue';
+import { ref, onMounted, watch, computed } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
 import apiService from '../services/api.js';
+import authService from '../services/authService.js'; 
 
 export default {
   name: 'TeamDetails',
@@ -446,6 +448,20 @@ export default {
       }
     };
 
+    // Sprawdzenie czy użytkownik może zarządzać członkami zespołu
+    const canManageMembers = computed(() => {
+      const user = authService?.authState?.user;
+      if (!user) return false;
+      // Admin ma zawsze dostęp
+      if (user.role === 'administrator') return true;
+      // Kierownik tylko jeśli jest kierownikiem tego zespołu
+      // Załóżmy, że currentTeam.value.managerId to id kierownika zespołu
+      if (user.role === 'kierownik' && currentTeam.value.managerId && user.id === currentTeam.value.managerId) {
+        return true;
+      }
+      return false;
+    });
+
     // Monitorowanie parametru ID
     onMounted(() => {
       console.log("TeamDetails component mounted, pobieranie danych...");
@@ -478,7 +494,8 @@ export default {
       navigateToManageMembers,  // potrzebne do nawigacji
       navigateToTaskDetails,
       getPriorityName,
-      getPriorityText
+      getPriorityText,
+      canManageMembers
     };
   }
 };

--- a/frontend/src/components/TeamMembersManage.vue
+++ b/frontend/src/components/TeamMembersManage.vue
@@ -142,11 +142,14 @@ const fetchData = async () => {
     
     // Fetch all active users
     const users = await userService.getActiveUsers();
-    employees.value = users.map(user => ({
-      id: user.id,
-      name: `${user.firstName} ${user.lastName}`,
-      email: user.email
-    }));
+    // Filtrowanie tylko pracowników
+    employees.value = users
+      .filter(user => user.role === 'pracownik')
+      .map(user => ({
+        id: user.id,
+        name: `${user.firstName} ${user.lastName}`,
+        email: user.email
+      }));
 
     // Fetch current team members using validated teamId
     const teamMembers = await teamService.getTeamMembers(teamId.value);

--- a/frontend/src/components/UserSettings.vue
+++ b/frontend/src/components/UserSettings.vue
@@ -21,7 +21,19 @@
         {{ successMessage }}
       </div>
 
-      <!-- Pole formularza -->
+      <!-- Pole formularza: Username -->
+      <div class="flex items-center mb-4">
+        <label class="w-40 font-semibold">Nazwa użytkownika</label>
+        <input
+          type="text"
+          v-model="user.username"
+          class="flex-1 px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary bg-white"
+          placeholder="Wpisz nazwę użytkownika"
+          required
+        />
+      </div>
+
+      <!-- Pole formularza: Imię -->
       <div class="flex items-center mb-4">
         <label class="w-40 font-semibold">Imię</label>
         <input

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -1,6 +1,7 @@
 import { createApp } from 'vue';
 import App from './App.vue';
 import router from '../router/router.js'; // Import the router
+import './assets/datepicker.css' // Import the datepicker CSS
 
 import './style.css';
 

--- a/frontend/src/services/authService.js
+++ b/frontend/src/services/authService.js
@@ -101,4 +101,5 @@ const authService = {
   }
 };
 
+export { authState }; 
 export default authService;

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -33,5 +33,22 @@ export default {
       },
     },
   },
-  plugins: [],
+  plugins: [
+    function({ addBase }) {
+      addBase({
+        // Style dla Vue3 Datepicker
+        '.datepicker-wrapper input[type="text"]': {
+          'background-color': 'white !important',
+          'color': 'black !important',
+          'border': '1px solid #d1d5db !important',
+          'border-radius': '0.375rem !important',
+        },
+        '.datepicker-wrapper input:focus': {
+          'outline': 'none !important',
+          'box-shadow': '0 0 0 2px #3F51B5 !important',
+          'border-color': '#3F51B5 !important',
+        },
+      })
+    }
+  ],
 }


### PR DESCRIPTION
- Crud personal data only admin and manager 
- display managers - does not display admins (when creating a team)
- task comments - can be deleted by: comment owner, team manager (to which the task is assigned), admin all <- TO CHECK
- team member management - remove managers and admins
- upcoming tasks renamed to tasks
- remove the option to deactivate the administrator account
- limit display of teams (to members, admin sees all)
- fix calendar in AddTask
- gui remodel (more intuitive tabs)
- added vue datepicker to generate reports
- add active tab management in navbar (active tab has thicker border)

How new modules work (RaportMenu, TaskMenu, AdminPanelMenu):
Main module with title, buttons to previous main modules modules (e.g. RaportGenerate, RaportHistory) are displayed underneath

- Raports

![image](https://github.com/user-attachments/assets/4f74c9d2-036b-4a98-9c9d-3d8f95e7bfb3)
![image](https://github.com/user-attachments/assets/cc455455-3513-4bae-b7ac-276f3b04cc85)

- Tasks

![image](https://github.com/user-attachments/assets/3f574398-3e5b-4708-9ee9-75f5e50e9a13)
![image](https://github.com/user-attachments/assets/17b4c799-2bd6-4405-806a-822246a0d43e)

- Admin Panel

![image](https://github.com/user-attachments/assets/220a2e8c-6ee3-40e2-be34-525908f5d0cf)
![image](https://github.com/user-attachments/assets/b7fad084-f7e6-4e1f-917d-6f3a64ff6843)

Vue Datepicker added to modules: RaportGenerate, AddTask, EditTask
![image](https://github.com/user-attachments/assets/68d4ee98-0bba-4769-a836-497fd303c037)

