### PR TITLE
Feature/add team manager endpoint

### DIFF
--- a/backend/src/main/java/com/example/backend/controllers/TeamController.java
+++ b/backend/src/main/java/com/example/backend/controllers/TeamController.java
@@ -1,6 +1,8 @@
 package com.example.backend.controllers;
 
 import com.example.backend.dto.TeamDTO;
+import com.example.backend.dto.UserDTO;
+import com.example.backend.dto.UserResponseDTO;
 import com.example.backend.services.TeamService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -168,5 +170,18 @@ public class TeamController {
         return teamService.deactivateTeam(id)
                 .map(team -> new ResponseEntity<>(team, HttpStatus.OK))
                 .orElse(new ResponseEntity<>(HttpStatus.NOT_FOUND));
+    }
+
+    /**
+     * Pobiera dane kierownika zespołu o podanym ID.
+     *
+     * @param id Identyfikator zespołu
+     * @return Dane kierownika zespołu lub status 404, jeśli zespół nie istnieje
+     */
+    @GetMapping("/{id}/manager")
+    public ResponseEntity<UserResponseDTO> getTeamManager(@PathVariable Integer id) {
+        return teamService.getTeamManager(id)
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.notFound().build());
     }
 }

--- a/backend/src/main/java/com/example/backend/services/TeamService.java
+++ b/backend/src/main/java/com/example/backend/services/TeamService.java
@@ -2,6 +2,7 @@ package com.example.backend.services;
 
 import com.example.backend.dto.TeamDTO;
 import com.example.backend.dto.UserDTO;
+import com.example.backend.dto.UserResponseDTO;
 import com.example.backend.models.Team;
 import com.example.backend.models.User;
 import com.example.backend.repository.TaskRepository;
@@ -210,5 +211,34 @@ public class TeamService {
      */
     public boolean existsById(Integer id) {
         return teamRepository.existsById(id);
+    }
+
+    /**
+     * Pobiera dane kierownika zespołu jako DTO.
+     *
+     * @param teamId Identyfikator zespołu
+     * @return Opcjonalne dane kierownika zespołu, jeśli zespół istnieje
+     */
+    public Optional<UserResponseDTO> getTeamManager(Integer teamId) {
+        return teamRepository.findById(teamId)
+                .map(team -> mapUserToResponseDTO(team.getManager()));
+    }
+
+    private UserResponseDTO mapUserToResponseDTO(User user) {
+        if (user == null) return null;
+
+        UserResponseDTO dto = new UserResponseDTO();
+        dto.setId(user.getId());
+        dto.setUsername(user.getUsername());
+        dto.setEmail(user.getEmail());
+        dto.setFirstName(user.getFirstName());
+        dto.setLastName(user.getLastName());
+        dto.setPhone(user.getPhone());
+        dto.setRole(user.getRole());
+        dto.setIsActive(user.getIsActive());
+        dto.setCreatedAt(user.getCreatedAt());
+        dto.setLastLogin(user.getLastLogin());
+
+        return dto;
     }
 }


### PR DESCRIPTION
## **Add Team Manager Endpoint**
### **📝 Description**
This PR adds a new API endpoint to retrieve team manager information. The frontend team requested this functionality to display manager details in team-related views.

### **🚀 Changes Made**
New Endpoint
`GET /database/teams/{id}/manager`
- Returns team manager data without sensitive information (password field excluded)
- Returns 404 Not Found for non-existent teams

### **Files Modified**
`TeamService.java` - Added getTeamManager() method and mapUserToResponseDTO() helper
`TeamController.java` - Added new endpoint with proper error handling

### **🔒 Security Considerations**
Uses UserResponseDTO instead of UserDTO to ensure password field is never returned
Follows existing security patterns used in AuthController
No sensitive data exposure in API responses